### PR TITLE
Extend README with usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # PriceScout
 
 Fully deployable with Flask, Playwright, scrapers, and working UI.
+
+## Usage
+
+Install the required dependencies and Playwright browsers:
+
+```bash
+pip install -r requirements.txt
+playwright install
+```
+
+Start the development server:
+
+```bash
+python app.py
+```


### PR DESCRIPTION
## Summary
- add instructions for installing requirements, installing Playwright browsers, and starting the development server

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b11431aa4832dbec58b74b9d11bb6