### PR TITLE
Remove placeholder sample prices from scrapers

### DIFF
--- a/scrapers/fixez.py
+++ b/scrapers/fixez.py
@@ -9,14 +9,7 @@ def scrape_fixez(query):
     search_url = f"{BASE}/search?keywords={query}"
     html = safe_get(search_url)
     if not html:
-        return [{
-            "title": f"Fixez sample result for '{query}'",
-            "price": 19.99,
-            "in_stock": True,
-            "source": "Fixez",
-            "link": search_url,
-            "image": "https://via.placeholder.com/100",
-        }]
+        return []
 
     soup = BeautifulSoup(html, "html.parser")
     link_tag = soup.select_one("a.product-item-link")
@@ -27,6 +20,8 @@ def scrape_fixez(query):
     title = link_tag.get_text(strip=True)
 
     prod_html = safe_get(link)
+    if not prod_html:
+        return []
     prod_soup = BeautifulSoup(prod_html, "html.parser")
     price_tag = prod_soup.select_one("span.price")
     price = parse_price(price_tag.get_text()) if price_tag else 0.0

--- a/scrapers/laptopscreen.py
+++ b/scrapers/laptopscreen.py
@@ -9,14 +9,7 @@ def scrape_laptopscreen(query):
     search_url = f"{BASE}/search?q={query}"
     html = safe_get(search_url)
     if not html:
-        return [{
-            "title": f"Laptopscreen sample result for '{query}'",
-            "price": 19.99,
-            "in_stock": True,
-            "source": "Laptopscreen",
-            "link": search_url,
-            "image": "https://via.placeholder.com/100",
-        }]
+        return []
 
     soup = BeautifulSoup(html, "html.parser")
     link_tag = soup.select_one("a.product-item-link")
@@ -27,6 +20,8 @@ def scrape_laptopscreen(query):
     title = link_tag.get_text(strip=True)
 
     prod_html = safe_get(link)
+    if not prod_html:
+        return []
     prod_soup = BeautifulSoup(prod_html, "html.parser")
     price_tag = prod_soup.select_one("span.price")
     price = parse_price(price_tag.get_text()) if price_tag else 0.0

--- a/scrapers/mengtor.py
+++ b/scrapers/mengtor.py
@@ -9,14 +9,7 @@ def scrape_mengtor(query):
     search_url = f"{BASE}/search?q={query}"
     html = safe_get(search_url)
     if not html:
-        return [{
-            "title": f"Mengtor sample result for '{query}'",
-            "price": 19.99,
-            "in_stock": True,
-            "source": "Mengtor",
-            "link": search_url,
-            "image": "https://via.placeholder.com/100",
-        }]
+        return []
 
     soup = BeautifulSoup(html, "html.parser")
     link_tag = soup.select_one("a.product-item-link")
@@ -27,6 +20,8 @@ def scrape_mengtor(query):
     title = link_tag.get_text(strip=True)
 
     prod_html = safe_get(link)
+    if not prod_html:
+        return []
     prod_soup = BeautifulSoup(prod_html, "html.parser")
     price_tag = prod_soup.select_one("span.price")
     price = parse_price(price_tag.get_text()) if price_tag else 0.0

--- a/scrapers/mobilesentrix.py
+++ b/scrapers/mobilesentrix.py
@@ -9,14 +9,7 @@ def scrape_mobilesentrix(query):
     search_url = f"{BASE}/search?q={query}"
     html = safe_get(search_url)
     if not html:
-        return [{
-            "title": f"MobileSentrix sample result for '{query}'",
-            "price": 19.99,
-            "in_stock": True,
-            "source": "MobileSentrix",
-            "link": search_url,
-            "image": "https://via.placeholder.com/100",
-        }]
+        return []
 
     soup = BeautifulSoup(html, "html.parser")
     link_tag = soup.select_one("a.product-item-link")
@@ -27,6 +20,8 @@ def scrape_mobilesentrix(query):
     title = link_tag.get_text(strip=True)
 
     prod_html = safe_get(link)
+    if not prod_html:
+        return []
     prod_soup = BeautifulSoup(prod_html, "html.parser")
     price_tag = prod_soup.select_one("span.price")
     price = parse_price(price_tag.get_text()) if price_tag else 0.0


### PR DESCRIPTION
## Summary
- Stop returning fake $19.99 results when scraping fails for Fixez, Laptopscreen, Mengtor and MobileSentrix
- Return no results if search or product pages cannot be retrieved, allowing actual site prices to surface

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68af5d336828832db9f4b75637a770bf