### PR TITLE
Remove placeholder sample prices from scrapers

### DIFF
--- a/scrapers/fixez.py
+++ b/scrapers/fixez.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from urllib.parse import urljoin, quote_plus
 from bs4 import BeautifulSoup
 from .utils import safe_get, parse_price
 
@@ -6,34 +6,24 @@ BASE = "https://www.fixez.com"
 
 
 def scrape_fixez(query):
-    search_url = f"{BASE}/search?keywords={query}"
+    search_url = f"{BASE}/search?keywords={quote_plus(query)}"
     html = safe_get(search_url)
     if not html:
-        return [{
-            "title": f"Fixez sample result for '{query}'",
-            "price": 19.99,
-            "in_stock": True,
-            "source": "Fixez",
-            "link": search_url,
-            "image": "https://via.placeholder.com/100",
-        }]
-
-    soup = BeautifulSoup(html, "html.parser")
-    link_tag = soup.select_one("a.product-item-link")
-    if not link_tag:
         return []
 
-    link = urljoin(BASE, link_tag.get("href", ""))
-    title = link_tag.get_text(strip=True)
+    soup = BeautifulSoup(html, "html.parser")
+    item = soup.select_one("li.product-item")
+    if not item:
+        return []
 
-    prod_html = safe_get(link)
-    prod_soup = BeautifulSoup(prod_html, "html.parser")
-    price_tag = prod_soup.select_one("span.price")
+    link_tag = item.select_one("a.product-item-link") or item.select_one("a")
+    price_tag = item.select_one("span.price")
+    image_tag = item.select_one("img")
+
+    link = urljoin(BASE, link_tag.get("href", "")) if link_tag else search_url
+    title = link_tag.get_text(strip=True) if link_tag else query
     price = parse_price(price_tag.get_text()) if price_tag else 0.0
-    in_stock = (
-        prod_soup.find(string=lambda s: s and "out of stock" in s.lower()) is None
-    )
-    image_tag = prod_soup.select_one("img")
+    in_stock = item.find(string=lambda s: s and "out of stock" in s.lower()) is None
     image = (
         urljoin(BASE, image_tag["src"])
         if image_tag and image_tag.has_attr("src")
@@ -42,7 +32,7 @@ def scrape_fixez(query):
 
     return [
         {
-            "title": title or query,
+            "title": title,
             "price": price,
             "in_stock": in_stock,
             "source": "Fixez",

--- a/scrapers/laptopscreen.py
+++ b/scrapers/laptopscreen.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from urllib.parse import urljoin, quote_plus
 from bs4 import BeautifulSoup
 from .utils import safe_get, parse_price
 
@@ -6,34 +6,24 @@ BASE = "https://www.laptopscreen.com"
 
 
 def scrape_laptopscreen(query):
-    search_url = f"{BASE}/search?q={query}"
+    search_url = f"{BASE}/search?q={quote_plus(query)}"
     html = safe_get(search_url)
     if not html:
-        return [{
-            "title": f"Laptopscreen sample result for '{query}'",
-            "price": 19.99,
-            "in_stock": True,
-            "source": "Laptopscreen",
-            "link": search_url,
-            "image": "https://via.placeholder.com/100",
-        }]
-
-    soup = BeautifulSoup(html, "html.parser")
-    link_tag = soup.select_one("a.product-item-link")
-    if not link_tag:
         return []
 
-    link = urljoin(BASE, link_tag.get("href", ""))
-    title = link_tag.get_text(strip=True)
+    soup = BeautifulSoup(html, "html.parser")
+    item = soup.select_one("li.product-item")
+    if not item:
+        return []
 
-    prod_html = safe_get(link)
-    prod_soup = BeautifulSoup(prod_html, "html.parser")
-    price_tag = prod_soup.select_one("span.price")
+    link_tag = item.select_one("a.product-item-link") or item.select_one("a")
+    price_tag = item.select_one("span.price")
+    image_tag = item.select_one("img")
+
+    link = urljoin(BASE, link_tag.get("href", "")) if link_tag else search_url
+    title = link_tag.get_text(strip=True) if link_tag else query
     price = parse_price(price_tag.get_text()) if price_tag else 0.0
-    in_stock = (
-        prod_soup.find(string=lambda s: s and "out of stock" in s.lower()) is None
-    )
-    image_tag = prod_soup.select_one("img")
+    in_stock = item.find(string=lambda s: s and "out of stock" in s.lower()) is None
     image = (
         urljoin(BASE, image_tag["src"])
         if image_tag and image_tag.has_attr("src")
@@ -42,7 +32,7 @@ def scrape_laptopscreen(query):
 
     return [
         {
-            "title": title or query,
+            "title": title,
             "price": price,
             "in_stock": in_stock,
             "source": "Laptopscreen",

--- a/scrapers/mengtor.py
+++ b/scrapers/mengtor.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from urllib.parse import urljoin, quote_plus
 from bs4 import BeautifulSoup
 from .utils import safe_get, parse_price
 
@@ -6,34 +6,24 @@ BASE = "https://www.mengtor.com"
 
 
 def scrape_mengtor(query):
-    search_url = f"{BASE}/search?q={query}"
+    search_url = f"{BASE}/search?q={quote_plus(query)}"
     html = safe_get(search_url)
     if not html:
-        return [{
-            "title": f"Mengtor sample result for '{query}'",
-            "price": 19.99,
-            "in_stock": True,
-            "source": "Mengtor",
-            "link": search_url,
-            "image": "https://via.placeholder.com/100",
-        }]
-
-    soup = BeautifulSoup(html, "html.parser")
-    link_tag = soup.select_one("a.product-item-link")
-    if not link_tag:
         return []
 
-    link = urljoin(BASE, link_tag.get("href", ""))
-    title = link_tag.get_text(strip=True)
+    soup = BeautifulSoup(html, "html.parser")
+    item = soup.select_one("li.product-item")
+    if not item:
+        return []
 
-    prod_html = safe_get(link)
-    prod_soup = BeautifulSoup(prod_html, "html.parser")
-    price_tag = prod_soup.select_one("span.price")
+    link_tag = item.select_one("a.product-item-link") or item.select_one("a")
+    price_tag = item.select_one("span.price")
+    image_tag = item.select_one("img")
+
+    link = urljoin(BASE, link_tag.get("href", "")) if link_tag else search_url
+    title = link_tag.get_text(strip=True) if link_tag else query
     price = parse_price(price_tag.get_text()) if price_tag else 0.0
-    in_stock = (
-        prod_soup.find(string=lambda s: s and "out of stock" in s.lower()) is None
-    )
-    image_tag = prod_soup.select_one("img")
+    in_stock = item.find(string=lambda s: s and "out of stock" in s.lower()) is None
     image = (
         urljoin(BASE, image_tag["src"])
         if image_tag and image_tag.has_attr("src")
@@ -42,7 +32,7 @@ def scrape_mengtor(query):
 
     return [
         {
-            "title": title or query,
+            "title": title,
             "price": price,
             "in_stock": in_stock,
             "source": "Mengtor",

--- a/scrapers/mobilesentrix.py
+++ b/scrapers/mobilesentrix.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from urllib.parse import urljoin, quote_plus
 from bs4 import BeautifulSoup
 from .utils import safe_get, parse_price
 
@@ -6,34 +6,24 @@ BASE = "https://www.mobilesentrix.com"
 
 
 def scrape_mobilesentrix(query):
-    search_url = f"{BASE}/search?q={query}"
+    search_url = f"{BASE}/search?q={quote_plus(query)}"
     html = safe_get(search_url)
     if not html:
-        return [{
-            "title": f"MobileSentrix sample result for '{query}'",
-            "price": 19.99,
-            "in_stock": True,
-            "source": "MobileSentrix",
-            "link": search_url,
-            "image": "https://via.placeholder.com/100",
-        }]
-
-    soup = BeautifulSoup(html, "html.parser")
-    link_tag = soup.select_one("a.product-item-link")
-    if not link_tag:
         return []
 
-    link = urljoin(BASE, link_tag.get("href", ""))
-    title = link_tag.get_text(strip=True)
+    soup = BeautifulSoup(html, "html.parser")
+    item = soup.select_one("li.product-item")
+    if not item:
+        return []
 
-    prod_html = safe_get(link)
-    prod_soup = BeautifulSoup(prod_html, "html.parser")
-    price_tag = prod_soup.select_one("span.price")
+    link_tag = item.select_one("a.product-item-link") or item.select_one("a")
+    price_tag = item.select_one("span.price")
+    image_tag = item.select_one("img")
+
+    link = urljoin(BASE, link_tag.get("href", "")) if link_tag else search_url
+    title = link_tag.get_text(strip=True) if link_tag else query
     price = parse_price(price_tag.get_text()) if price_tag else 0.0
-    in_stock = (
-        prod_soup.find(string=lambda s: s and "out of stock" in s.lower()) is None
-    )
-    image_tag = prod_soup.select_one("img")
+    in_stock = item.find(string=lambda s: s and "out of stock" in s.lower()) is None
     image = (
         urljoin(BASE, image_tag["src"])
         if image_tag and image_tag.has_attr("src")
@@ -42,7 +32,7 @@ def scrape_mobilesentrix(query):
 
     return [
         {
-            "title": title or query,
+            "title": title,
             "price": price,
             "in_stock": in_stock,
             "source": "MobileSentrix",

--- a/scrapers/utils.py
+++ b/scrapers/utils.py
@@ -3,12 +3,22 @@ import requests
 from bs4 import BeautifulSoup
 from urllib.parse import urljoin
 
-HEADERS = {"User-Agent": "Mozilla/5.0"}
+# Use a full desktop browser header to avoid basic bot blocking
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/113.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
+}
 
 
-def safe_get(url):
+def safe_get(url, params=None):
+    """Fetch *url* and return the text body, or an empty string on failure."""
     try:
-        resp = requests.get(url, headers=HEADERS, timeout=10)
+        resp = requests.get(url, params=params, headers=HEADERS, timeout=10)
         resp.raise_for_status()
         return resp.text
     except Exception:


### PR DESCRIPTION
## Summary
- Stop returning fake $19.99 results when scraping fails for Fixez, Laptopscreen, Mengtor and MobileSentrix
- Return no results if search or product pages cannot be retrieved, allowing actual site prices to surface
- Pull result details directly from search pages to reduce failures and capture actual distributor prices
- Use fuller browser headers in `safe_get` for better page retrieval

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68af5d336828832db9f4b75637a770bf