### PR TITLE
Fix indentation issues in scrapers after failed merge

### DIFF
--- a/scrapers/fixez.py
+++ b/scrapers/fixez.py
@@ -29,7 +29,6 @@ def scrape_fixez(query):
         return []
     prod_soup = BeautifulSoup(prod_html, "html.parser")
     price_tag = prod_soup.select_one("span.price")
- main
     price = parse_price(price_tag.get_text()) if price_tag else 0.0
     in_stock = item.find(string=lambda s: s and "out of stock" in s.lower()) is None
     image = (

--- a/scrapers/laptopscreen.py
+++ b/scrapers/laptopscreen.py
@@ -29,7 +29,6 @@ def scrape_laptopscreen(query):
         return []
     prod_soup = BeautifulSoup(prod_html, "html.parser")
     price_tag = prod_soup.select_one("span.price")
-main
     price = parse_price(price_tag.get_text()) if price_tag else 0.0
     in_stock = item.find(string=lambda s: s and "out of stock" in s.lower()) is None
     image = (

--- a/scrapers/mengtor.py
+++ b/scrapers/mengtor.py
@@ -28,7 +28,6 @@ def scrape_mengtor(query):
         return []
     prod_soup = BeautifulSoup(prod_html, "html.parser")
     price_tag = prod_soup.select_one("span.price")
-main
     price = parse_price(price_tag.get_text()) if price_tag else 0.0
     in_stock = item.find(string=lambda s: s and "out of stock" in s.lower()) is None
     image = (

--- a/scrapers/mobilesentrix.py
+++ b/scrapers/mobilesentrix.py
@@ -28,7 +28,6 @@ def scrape_mobilesentrix(query):
         return []
     prod_soup = BeautifulSoup(prod_html, "html.parser")
     price_tag = prod_soup.select_one("span.price")
- main
     price = parse_price(price_tag.get_text()) if price_tag else 0.0
     in_stock = item.find(string=lambda s: s and "out of stock" in s.lower()) is None
     image = (


### PR DESCRIPTION
## Summary
- remove stray `main` lines from scraper modules
- ensure product pricing and stock parsing works without syntax errors

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68af64f257dc832d9ebf70355508cbed