### PR TITLE
Refine product scrapers with product page details

### DIFF
--- a/scrapers/laptopscreen.py
+++ b/scrapers/laptopscreen.py
@@ -24,12 +24,6 @@ def scrape_laptopscreen(query):
     link = urljoin(BASE, link_tag.get("href", "")) if link_tag else search_url
     title = link_tag.get_text(strip=True) if link_tag else query
 
-    prod_html = safe_get(link)
-    if not prod_html:
-        return []
-    prod_soup = BeautifulSoup(prod_html, "html.parser")
-    price_tag = prod_soup.select_one("span.price")
-main
     price = parse_price(price_tag.get_text()) if price_tag else 0.0
     in_stock = item.find(string=lambda s: s and "out of stock" in s.lower()) is None
     image = (
@@ -37,6 +31,19 @@ main
         if image_tag and image_tag.has_attr("src")
         else "https://via.placeholder.com/100"
     )
+
+    prod_html = safe_get(link) if link_tag else None
+    if prod_html:
+        prod_soup = BeautifulSoup(prod_html, "html.parser")
+        prod_price = prod_soup.select_one("span.price")
+        if prod_price:
+            price = parse_price(prod_price.get_text())
+        in_stock = prod_soup.find(
+            string=lambda s: s and "out of stock" in s.lower()
+        ) is None
+        prod_img = prod_soup.select_one("img")
+        if prod_img and prod_img.has_attr("src"):
+            image = urljoin(BASE, prod_img["src"])
 
     return [
         {

--- a/scrapers/mengtor.py
+++ b/scrapers/mengtor.py
@@ -23,12 +23,6 @@ def scrape_mengtor(query):
     link = urljoin(BASE, link_tag.get("href", "")) if link_tag else search_url
     title = link_tag.get_text(strip=True) if link_tag else query
 
-    prod_html = safe_get(link)
-    if not prod_html:
-        return []
-    prod_soup = BeautifulSoup(prod_html, "html.parser")
-    price_tag = prod_soup.select_one("span.price")
-main
     price = parse_price(price_tag.get_text()) if price_tag else 0.0
     in_stock = item.find(string=lambda s: s and "out of stock" in s.lower()) is None
     image = (
@@ -36,6 +30,19 @@ main
         if image_tag and image_tag.has_attr("src")
         else "https://via.placeholder.com/100"
     )
+
+    prod_html = safe_get(link) if link_tag else None
+    if prod_html:
+        prod_soup = BeautifulSoup(prod_html, "html.parser")
+        prod_price = prod_soup.select_one("span.price")
+        if prod_price:
+            price = parse_price(prod_price.get_text())
+        in_stock = prod_soup.find(
+            string=lambda s: s and "out of stock" in s.lower()
+        ) is None
+        prod_img = prod_soup.select_one("img")
+        if prod_img and prod_img.has_attr("src"):
+            image = urljoin(BASE, prod_img["src"])
 
     return [
         {

--- a/scrapers/mobilesentrix.py
+++ b/scrapers/mobilesentrix.py
@@ -23,12 +23,6 @@ def scrape_mobilesentrix(query):
     link = urljoin(BASE, link_tag.get("href", "")) if link_tag else search_url
     title = link_tag.get_text(strip=True) if link_tag else query
 
-    prod_html = safe_get(link)
-    if not prod_html:
-        return []
-    prod_soup = BeautifulSoup(prod_html, "html.parser")
-    price_tag = prod_soup.select_one("span.price")
- main
     price = parse_price(price_tag.get_text()) if price_tag else 0.0
     in_stock = item.find(string=lambda s: s and "out of stock" in s.lower()) is None
     image = (
@@ -36,6 +30,19 @@ def scrape_mobilesentrix(query):
         if image_tag and image_tag.has_attr("src")
         else "https://via.placeholder.com/100"
     )
+
+    prod_html = safe_get(link) if link_tag else None
+    if prod_html:
+        prod_soup = BeautifulSoup(prod_html, "html.parser")
+        prod_price = prod_soup.select_one("span.price")
+        if prod_price:
+            price = parse_price(prod_price.get_text())
+        in_stock = prod_soup.find(
+            string=lambda s: s and "out of stock" in s.lower()
+        ) is None
+        prod_img = prod_soup.select_one("img")
+        if prod_img and prod_img.has_attr("src"):
+            image = urljoin(BASE, prod_img["src"])
 
     return [
         {


### PR DESCRIPTION
## Summary
- enhance LaptopScreen, Mengtor and MobileSentrix scrapers to fetch each product page for precise price, stock status and image

## Testing
- `python -m py_compile scrapers/laptopscreen.py scrapers/mengtor.py scrapers/mobilesentrix.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af65132004832d9d7c158526ff8c83