### PR TITLE
Handle price phrases and ranges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.venv/
+__pycache__/

--- a/scrapers/utils.py
+++ b/scrapers/utils.py
@@ -26,5 +26,28 @@ def safe_get(url, params=None):
 
 
 def parse_price(text):
-    match = re.search(r"([0-9]+(?:\.[0-9]+)?)", text.replace(",", ""))
-    return float(match.group(1)) if match else 0.0
+    """Extract a numeric price from *text*.
+
+    Common lead-in phrases such as "From" or "Starting at" are stripped
+    before parsing. When a price range like "$10-$20" is supplied, the
+    average of the bounds is returned. If no numbers can be found, ``0.0`` is
+    returned.
+    """
+
+    # Remove helpful but non-numeric phrases
+    normalized = re.sub(r"\b(from|starting at)\b", "", text, flags=re.I)
+
+    # Normalise dash types and remove thousands separators
+    normalized = normalized.replace("–", "-").replace(",", "")
+
+    # Find all numbers in the string
+    numbers = re.findall(r"([0-9]+(?:\.[0-9]+)?)", normalized)
+    if not numbers:
+        return 0.0
+
+    # If a range is detected, return the average of the first two numbers
+    if "-" in normalized and len(numbers) >= 2:
+        values = [float(n) for n in numbers[:2]]
+        return sum(values) / len(values)
+
+    return float(numbers[0])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,11 @@
+import pytest
+from scrapers.utils import parse_price
+
+def test_parse_price_single():
+    assert parse_price("Starting at $1,234.50") == pytest.approx(1234.50)
+
+def test_parse_price_range():
+    assert parse_price("$10–$20") == pytest.approx(15.0)
+
+def test_parse_price_malformed():
+    assert parse_price("Free") == 0.0


### PR DESCRIPTION
## Summary
- normalize leading phrases like "From" or "Starting at" before extracting prices
- average detected price ranges (e.g. $10-$20)
- add tests for single prices, ranges, and malformed values

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
- `pip install pytest` *(fails: Could not find a version that satisfies the requirement pytest (ProxyError))*

------
https://chatgpt.com/codex/tasks/task_e_68af652d1c40832d9168034c6fb5eb29