### PR TITLE
Improve scraper robustness with Playwright and logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,10 +20,17 @@ def search():
     in_stock_only = request.args.get("inStock", "false").lower() == "true"
 
     results = []
-    results += scrape_mobilesentrix(query)
-    results += scrape_fixez(query)
-    results += scrape_mengtor(query)
-    results += scrape_laptopscreen(query)
+    sources = [
+        ("MobileSentrix", scrape_mobilesentrix),
+        ("Fixez", scrape_fixez),
+        ("Mengtor", scrape_mengtor),
+        ("Laptopscreen", scrape_laptopscreen),
+    ]
+    for name, scraper in sources:
+        try:
+            results += scraper(query)
+        except Exception:
+            app.logger.exception("Error scraping %s", name)
 
     if in_stock_only:
         results = [r for r in results if r["in_stock"]]

--- a/scrapers/fixez.py
+++ b/scrapers/fixez.py
@@ -1,63 +1,52 @@
-from urllib.parse import urljoin, quote_plus
+import logging
+from urllib.parse import quote_plus, urljoin
 from bs4 import BeautifulSoup
-from .utils import safe_get, parse_price
+from .utils import render_page, parse_price
 
 BASE = "https://www.fixez.com"
+logger = logging.getLogger(__name__)
 
 
 def scrape_fixez(query):
     search_url = f"{BASE}/search?keywords={quote_plus(query)}"
-    html = safe_get(search_url)
+    html = render_page(search_url, "li.product-item")
     if not html:
         return []
 
     soup = BeautifulSoup(html, "html.parser")
-    item = soup.select_one("li.product-item")
-    if not item:
+    items = soup.select("li.product-item") or soup.select("div.product-item")
+    if not items:
+        logger.warning("Fixez: no product items found for %s", query)
         return []
 
-    link_tag = item.select_one("a.product-item-link") or item.select_one("a")
-    price_tag = item.select_one("span.price")
-    image_tag = item.select_one("img")
+    results = []
+    for item in items:
+        link_tag = item.select_one("a.product-item-link") or item.select_one("a")
+        price_tag = item.select_one("span.price")
+        image_tag = item.select_one("img")
+        if not link_tag:
+            logger.warning("Fixez: missing link tag, skipping item")
+            continue
 
-    link = urljoin(BASE, link_tag.get("href", "")) if link_tag else search_url
-    title = link_tag.get_text(strip=True) if link_tag else query
+        link = urljoin(BASE, link_tag.get("href", ""))
+        title = link_tag.get_text(strip=True) or query
+        price = parse_price(price_tag.get_text()) if price_tag else 0.0
+        in_stock = item.find(string=lambda s: s and "out of stock" in s.lower()) is None
+        image = (
+            urljoin(BASE, image_tag["src"])
+            if image_tag and image_tag.has_attr("src")
+            else "https://via.placeholder.com/100"
+        )
 
+        results.append(
+            {
+                "title": title,
+                "price": price,
+                "in_stock": in_stock,
+                "source": "Fixez",
+                "link": link,
+                "image": image,
+            }
+        )
 
-    prod_html = safe_get(link)
-    if not prod_html:
-        return []
-    prod_soup = BeautifulSoup(prod_html, "html.parser")
-    price_tag = prod_soup.select_one("span.price")
-    price = parse_price(price_tag.get_text()) if price_tag else 0.0
-    in_stock = item.find(string=lambda s: s and "out of stock" in s.lower()) is None
-    image = (
-        urljoin(BASE, image_tag["src"])
-        if image_tag and image_tag.has_attr("src")
-        else "https://via.placeholder.com/100"
-    )
-
-    # Try to refine details from the product page; fall back to search info on failure
-    prod_html = safe_get(link) if link_tag else None
-    if prod_html:
-        prod_soup = BeautifulSoup(prod_html, "html.parser")
-        prod_price = prod_soup.select_one("span.price")
-        if prod_price:
-            price = parse_price(prod_price.get_text())
-        in_stock = prod_soup.find(
-            string=lambda s: s and "out of stock" in s.lower()
-        ) is None
-        prod_img = prod_soup.select_one("img")
-        if prod_img and prod_img.has_attr("src"):
-            image = urljoin(BASE, prod_img["src"])
-
-    return [
-        {
-            "title": title,
-            "price": price,
-            "in_stock": in_stock,
-            "source": "Fixez",
-            "link": link,
-            "image": image,
-        }
-    ]
+    return results

--- a/scrapers/laptopscreen.py
+++ b/scrapers/laptopscreen.py
@@ -1,49 +1,52 @@
-from urllib.parse import urljoin, quote_plus
+import logging
+from urllib.parse import quote_plus, urljoin
 from bs4 import BeautifulSoup
-from .utils import safe_get, parse_price
+from .utils import render_page, parse_price
 
 BASE = "https://www.laptopscreen.com"
+logger = logging.getLogger(__name__)
 
 
 def scrape_laptopscreen(query):
     search_url = f"{BASE}/search?q={quote_plus(query)}"
-    html = safe_get(search_url)
+    html = render_page(search_url, "li.product-item")
     if not html:
         return []
 
     soup = BeautifulSoup(html, "html.parser")
-    item = soup.select_one("li.product-item")
-    if not item:
+    items = soup.select("li.product-item") or soup.select("div.product-item")
+    if not items:
+        logger.warning("Laptopscreen: no product items found for %s", query)
         return []
 
-    link_tag = item.select_one("a.product-item-link") or item.select_one("a")
-    price_tag = item.select_one("span.price")
-    image_tag = item.select_one("img")
+    results = []
+    for item in items:
+        link_tag = item.select_one("a.product-item-link") or item.select_one("a")
+        price_tag = item.select_one("span.price")
+        image_tag = item.select_one("img")
+        if not link_tag:
+            logger.warning("Laptopscreen: missing link tag, skipping item")
+            continue
 
+        link = urljoin(BASE, link_tag.get("href", ""))
+        title = link_tag.get_text(strip=True) or query
+        price = parse_price(price_tag.get_text()) if price_tag else 0.0
+        in_stock = item.find(string=lambda s: s and "out of stock" in s.lower()) is None
+        image = (
+            urljoin(BASE, image_tag["src"])
+            if image_tag and image_tag.has_attr("src")
+            else "https://via.placeholder.com/100"
+        )
 
-    link = urljoin(BASE, link_tag.get("href", "")) if link_tag else search_url
-    title = link_tag.get_text(strip=True) if link_tag else query
+        results.append(
+            {
+                "title": title,
+                "price": price,
+                "in_stock": in_stock,
+                "source": "Laptopscreen",
+                "link": link,
+                "image": image,
+            }
+        )
 
-    prod_html = safe_get(link)
-    if not prod_html:
-        return []
-    prod_soup = BeautifulSoup(prod_html, "html.parser")
-    price_tag = prod_soup.select_one("span.price")
-    price = parse_price(price_tag.get_text()) if price_tag else 0.0
-    in_stock = item.find(string=lambda s: s and "out of stock" in s.lower()) is None
-    image = (
-        urljoin(BASE, image_tag["src"])
-        if image_tag and image_tag.has_attr("src")
-        else "https://via.placeholder.com/100"
-    )
-
-    return [
-        {
-            "title": title,
-            "price": price,
-            "in_stock": in_stock,
-            "source": "Laptopscreen",
-            "link": link,
-            "image": image,
-        }
-    ]
+    return results

--- a/scrapers/mengtor.py
+++ b/scrapers/mengtor.py
@@ -1,48 +1,52 @@
-from urllib.parse import urljoin, quote_plus
+import logging
+from urllib.parse import quote_plus, urljoin
 from bs4 import BeautifulSoup
-from .utils import safe_get, parse_price
+from .utils import render_page, parse_price
 
 BASE = "https://www.mengtor.com"
+logger = logging.getLogger(__name__)
 
 
 def scrape_mengtor(query):
     search_url = f"{BASE}/search?q={quote_plus(query)}"
-    html = safe_get(search_url)
+    html = render_page(search_url, "li.product-item")
     if not html:
         return []
 
     soup = BeautifulSoup(html, "html.parser")
-    item = soup.select_one("li.product-item")
-    if not item:
+    items = soup.select("li.product-item") or soup.select("div.product-item")
+    if not items:
+        logger.warning("Mengtor: no product items found for %s", query)
         return []
 
-    link_tag = item.select_one("a.product-item-link") or item.select_one("a")
-    price_tag = item.select_one("span.price")
-    image_tag = item.select_one("img")
+    results = []
+    for item in items:
+        link_tag = item.select_one("a.product-item-link") or item.select_one("a")
+        price_tag = item.select_one("span.price")
+        image_tag = item.select_one("img")
+        if not link_tag:
+            logger.warning("Mengtor: missing link tag, skipping item")
+            continue
 
-    link = urljoin(BASE, link_tag.get("href", "")) if link_tag else search_url
-    title = link_tag.get_text(strip=True) if link_tag else query
+        link = urljoin(BASE, link_tag.get("href", ""))
+        title = link_tag.get_text(strip=True) or query
+        price = parse_price(price_tag.get_text()) if price_tag else 0.0
+        in_stock = item.find(string=lambda s: s and "out of stock" in s.lower()) is None
+        image = (
+            urljoin(BASE, image_tag["src"])
+            if image_tag and image_tag.has_attr("src")
+            else "https://via.placeholder.com/100"
+        )
 
-    prod_html = safe_get(link)
-    if not prod_html:
-        return []
-    prod_soup = BeautifulSoup(prod_html, "html.parser")
-    price_tag = prod_soup.select_one("span.price")
-    price = parse_price(price_tag.get_text()) if price_tag else 0.0
-    in_stock = item.find(string=lambda s: s and "out of stock" in s.lower()) is None
-    image = (
-        urljoin(BASE, image_tag["src"])
-        if image_tag and image_tag.has_attr("src")
-        else "https://via.placeholder.com/100"
-    )
+        results.append(
+            {
+                "title": title,
+                "price": price,
+                "in_stock": in_stock,
+                "source": "Mengtor",
+                "link": link,
+                "image": image,
+            }
+        )
 
-    return [
-        {
-            "title": title,
-            "price": price,
-            "in_stock": in_stock,
-            "source": "Mengtor",
-            "link": link,
-            "image": image,
-        }
-    ]
+    return results

--- a/scrapers/mobilesentrix.py
+++ b/scrapers/mobilesentrix.py
@@ -1,48 +1,52 @@
-from urllib.parse import urljoin, quote_plus
+import logging
+from urllib.parse import quote_plus, urljoin
 from bs4 import BeautifulSoup
-from .utils import safe_get, parse_price
+from .utils import render_page, parse_price
 
 BASE = "https://www.mobilesentrix.com"
+logger = logging.getLogger(__name__)
 
 
 def scrape_mobilesentrix(query):
     search_url = f"{BASE}/search?q={quote_plus(query)}"
-    html = safe_get(search_url)
+    html = render_page(search_url, "li.product-item")
     if not html:
         return []
 
     soup = BeautifulSoup(html, "html.parser")
-    item = soup.select_one("li.product-item")
-    if not item:
+    items = soup.select("li.product-item") or soup.select("div.product-item")
+    if not items:
+        logger.warning("MobileSentrix: no product items found for %s", query)
         return []
 
-    link_tag = item.select_one("a.product-item-link") or item.select_one("a")
-    price_tag = item.select_one("span.price")
-    image_tag = item.select_one("img")
+    results = []
+    for item in items:
+        link_tag = item.select_one("a.product-item-link") or item.select_one("a")
+        price_tag = item.select_one("span.price")
+        image_tag = item.select_one("img")
+        if not link_tag:
+            logger.warning("MobileSentrix: missing link tag, skipping item")
+            continue
 
-    link = urljoin(BASE, link_tag.get("href", "")) if link_tag else search_url
-    title = link_tag.get_text(strip=True) if link_tag else query
+        link = urljoin(BASE, link_tag.get("href", ""))
+        title = link_tag.get_text(strip=True) or query
+        price = parse_price(price_tag.get_text()) if price_tag else 0.0
+        in_stock = item.find(string=lambda s: s and "out of stock" in s.lower()) is None
+        image = (
+            urljoin(BASE, image_tag["src"])
+            if image_tag and image_tag.has_attr("src")
+            else "https://via.placeholder.com/100"
+        )
 
-    prod_html = safe_get(link)
-    if not prod_html:
-        return []
-    prod_soup = BeautifulSoup(prod_html, "html.parser")
-    price_tag = prod_soup.select_one("span.price")
-    price = parse_price(price_tag.get_text()) if price_tag else 0.0
-    in_stock = item.find(string=lambda s: s and "out of stock" in s.lower()) is None
-    image = (
-        urljoin(BASE, image_tag["src"])
-        if image_tag and image_tag.has_attr("src")
-        else "https://via.placeholder.com/100"
-    )
+        results.append(
+            {
+                "title": title,
+                "price": price,
+                "in_stock": in_stock,
+                "source": "MobileSentrix",
+                "link": link,
+                "image": image,
+            }
+        )
 
-    return [
-        {
-            "title": title,
-            "price": price,
-            "in_stock": in_stock,
-            "source": "MobileSentrix",
-            "link": link,
-            "image": image,
-        }
-    ]
+    return results

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Ensure the project root is on the import path for scraper modules
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_fixez.py
+++ b/tests/test_fixez.py
@@ -1,0 +1,27 @@
+from scrapers import fixez
+
+SEARCH_HTML = """
+<ul>
+<li class="product-item">
+  <a class="product-item-link" href="/p1">Item One</a>
+  <img src="/img1.jpg"/>
+  <span class="price">$10.00</span>
+</li>
+<li class="product-item">
+  <a class="product-item-link" href="/p2">Item Two</a>
+  <img src="/img2.jpg"/>
+  <span class="price">$20.00</span>
+</li>
+</ul>
+"""
+
+def test_scrape_fixez(monkeypatch):
+    monkeypatch.setattr(fixez, "render_page", lambda url, wait_selector=None: SEARCH_HTML)
+    results = fixez.scrape_fixez("screen")
+    assert len(results) == 2
+    first = results[0]
+    assert first["title"] == "Item One"
+    assert first["price"] == 10.0
+    assert first["link"] == "https://www.fixez.com/p1"
+    assert first["image"] == "https://www.fixez.com/img1.jpg"
+    assert first["source"] == "Fixez"

--- a/tests/test_laptopscreen.py
+++ b/tests/test_laptopscreen.py
@@ -1,0 +1,27 @@
+from scrapers import laptopscreen
+
+SEARCH_HTML = """
+<ul>
+<li class="product-item">
+  <a class="product-item-link" href="/p1">Item One</a>
+  <img src="/img1.jpg"/>
+  <span class="price">$10.00</span>
+</li>
+<li class="product-item">
+  <a class="product-item-link" href="/p2">Item Two</a>
+  <img src="/img2.jpg"/>
+  <span class="price">$20.00</span>
+</li>
+</ul>
+"""
+
+def test_scrape_laptopscreen(monkeypatch):
+    monkeypatch.setattr(laptopscreen, "render_page", lambda url, wait_selector=None: SEARCH_HTML)
+    results = laptopscreen.scrape_laptopscreen("screen")
+    assert len(results) == 2
+    first = results[0]
+    assert first["title"] == "Item One"
+    assert first["price"] == 10.0
+    assert first["link"] == "https://www.laptopscreen.com/p1"
+    assert first["image"] == "https://www.laptopscreen.com/img1.jpg"
+    assert first["source"] == "Laptopscreen"

--- a/tests/test_mengtor.py
+++ b/tests/test_mengtor.py
@@ -1,0 +1,27 @@
+from scrapers import mengtor
+
+SEARCH_HTML = """
+<ul>
+<li class="product-item">
+  <a class="product-item-link" href="/p1">Item One</a>
+  <img src="/img1.jpg"/>
+  <span class="price">$10.00</span>
+</li>
+<li class="product-item">
+  <a class="product-item-link" href="/p2">Item Two</a>
+  <img src="/img2.jpg"/>
+  <span class="price">$20.00</span>
+</li>
+</ul>
+"""
+
+def test_scrape_mengtor(monkeypatch):
+    monkeypatch.setattr(mengtor, "render_page", lambda url, wait_selector=None: SEARCH_HTML)
+    results = mengtor.scrape_mengtor("screen")
+    assert len(results) == 2
+    first = results[0]
+    assert first["title"] == "Item One"
+    assert first["price"] == 10.0
+    assert first["link"] == "https://www.mengtor.com/p1"
+    assert first["image"] == "https://www.mengtor.com/img1.jpg"
+    assert first["source"] == "Mengtor"

--- a/tests/test_mobilesentrix.py
+++ b/tests/test_mobilesentrix.py
@@ -1,0 +1,27 @@
+from scrapers import mobilesentrix
+
+SEARCH_HTML = """
+<ul>
+<li class="product-item">
+  <a class="product-item-link" href="/p1">Item One</a>
+  <img src="/img1.jpg"/>
+  <span class="price">$10.00</span>
+</li>
+<li class="product-item">
+  <a class="product-item-link" href="/p2">Item Two</a>
+  <img src="/img2.jpg"/>
+  <span class="price">$20.00</span>
+</li>
+</ul>
+"""
+
+def test_scrape_mobilesentrix(monkeypatch):
+    monkeypatch.setattr(mobilesentrix, "render_page", lambda url, wait_selector=None: SEARCH_HTML)
+    results = mobilesentrix.scrape_mobilesentrix("screen")
+    assert len(results) == 2
+    first = results[0]
+    assert first["title"] == "Item One"
+    assert first["price"] == 10.0
+    assert first["link"] == "https://www.mobilesentrix.com/p1"
+    assert first["image"] == "https://www.mobilesentrix.com/img1.jpg"
+    assert first["source"] == "MobileSentrix"


### PR DESCRIPTION
## Summary
- log network errors in safe_get and add Playwright-based render_page helper
- replace brittle single-item scrapers with Playwright-powered versions that return multiple products
- isolate individual scraper failures in `/api/search` and add unit tests for each scraper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af674d2e10832dac93590a962473de