### PR TITLE
Ensure Playwright is installed before app startup

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,2 +1,3 @@
-startCommand: python app.py
-buildCommand: playwright install --with-deps
+startCommand: >-
+  playwright install chromium --with-deps &&
+  python app.py


### PR DESCRIPTION
## Summary
- run `playwright install chromium --with-deps` before launching the app to guarantee browser availability during start up

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af8e5598c8832d9067389dd68efa36